### PR TITLE
Kepub simplification, and small logic fix.

### DIFF
--- a/kobo-uncaged/main.go
+++ b/kobo-uncaged/main.go
@@ -363,7 +363,8 @@ func (ku *KoboUncaged) readMDfile() error {
 	// make a temporary map for easy searching later
 	tmpMap := make(map[string]int, len(koboMD))
 	for n, md := range koboMD {
-		contentID := lpathToContentID(md.Lpath, string(ku.contentIDprefix))
+		newLpath := lpathKepubConvert(md.Lpath)
+		contentID := lpathToContentID(newLpath, string(ku.contentIDprefix))
 		tmpMap[contentID] = n
 	}
 	log.Println(body, "Gathering metadata")
@@ -719,6 +720,7 @@ func (ku *KoboUncaged) SaveBook(md map[string]interface{}, len int, lastBook boo
 	// The calibre wireless driver does not sanitize the filepath for us. We sanitize it here,
 	// and if lpath changes, inform Calibre of the new lpath.
 	newLpath = ku.invalidCharsRegex.ReplaceAllString(koboMD.Lpath, "_")
+	newLpath = lpathKepubConvert(newLpath)
 	if newLpath != koboMD.Lpath {
 		koboMD.Lpath = newLpath
 	} else {

--- a/kobo-uncaged/main.go
+++ b/kobo-uncaged/main.go
@@ -737,8 +737,6 @@ func (ku *KoboUncaged) SaveBook(md map[string]interface{}, len int, lastBook boo
 	if err != nil {
 		return nil, "", err
 	}
-
-	ku.metadataMap[cID] = koboMD
 	ku.updatedMetadata = append(ku.updatedMetadata, cID)
 	// Note, the JSON format for covers should be in the form 'thumbnail: [w, h, "base64string"]'
 	if kt := koboMD.Thumbnail; kt != nil {
@@ -749,6 +747,7 @@ func (ku *KoboUncaged) SaveBook(md map[string]interface{}, len int, lastBook boo
 	if err != nil {
 		log.Print(err)
 	}
+	ku.metadataMap[cID] = koboMD
 	if lastBook {
 		ku.writeMDfile()
 		ku.writeUpdateMDfile()

--- a/kobo-uncaged/main.go
+++ b/kobo-uncaged/main.go
@@ -363,8 +363,7 @@ func (ku *KoboUncaged) readMDfile() error {
 	// make a temporary map for easy searching later
 	tmpMap := make(map[string]int, len(koboMD))
 	for n, md := range koboMD {
-		newLpath := lpathKepubConvert(md.Lpath)
-		contentID := lpathToContentID(newLpath, string(ku.contentIDprefix))
+		contentID := lpathToContentID(lpathKepubConvert(md.Lpath), string(ku.contentIDprefix))
 		tmpMap[contentID] = n
 	}
 	log.Println(body, "Gathering metadata")
@@ -720,6 +719,8 @@ func (ku *KoboUncaged) SaveBook(md map[string]interface{}, len int, lastBook boo
 	// The calibre wireless driver does not sanitize the filepath for us. We sanitize it here,
 	// and if lpath changes, inform Calibre of the new lpath.
 	newLpath = ku.invalidCharsRegex.ReplaceAllString(koboMD.Lpath, "_")
+	// Also, for kepub files, Calibre defaults to using "book/path.kepub"
+	// but we require "book/path.kepub.epub". We change that here if needed.
 	newLpath = lpathKepubConvert(newLpath)
 	if newLpath != koboMD.Lpath {
 		koboMD.Lpath = newLpath

--- a/kobo-uncaged/util.go
+++ b/kobo-uncaged/util.go
@@ -26,21 +26,18 @@ func lpathIsKepub(lpath string) bool {
 	return strings.HasSuffix(lpath, ".kepub")
 }
 
-func contentIDisKepub(contentID string) bool {
-	return strings.HasSuffix(contentID, ".kepub.epub")
-}
-
-func lpathToContentID(lpath, cidPrefix string) string {
+func lpathKepubConvert(lpath string) string {
 	if lpathIsKepub(lpath) {
 		lpath += ".epub"
 	}
+	return lpath
+}
+
+func lpathToContentID(lpath, cidPrefix string) string {
 	return cidPrefix + strings.TrimPrefix(lpath, "/")
 }
 
 func contentIDtoLpath(cid, cidPrefix string) string {
-	if contentIDisKepub(cid) {
-		cid = strings.TrimSuffix(cid, ".epub")
-	}
 	return strings.TrimPrefix(cid, cidPrefix)
 }
 

--- a/kobo-uncaged/util.go
+++ b/kobo-uncaged/util.go
@@ -18,10 +18,6 @@ func contentIDtoBkPath(rootDir, cid, cidPrefix string) string {
 	return filepath.Join(rootDir, strings.TrimPrefix(cid, cidPrefix))
 }
 
-func contentIDisBkDir(cid, cidPrefix string) bool {
-	return strings.HasPrefix(cid, cidPrefix)
-}
-
 func lpathIsKepub(lpath string) bool {
 	return strings.HasSuffix(lpath, ".kepub")
 }


### PR DESCRIPTION
The previous lpath `.kepub` to `kepub.epub` and back to `.kepub` is no longer required, now that we can inform Calibre of lpath changes.

This PR should also fix a small issue of an sql error when sending new books to device.