### PR TITLE
Switch thumbnail image resize library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/shermp/Kobo-UNCaGED
 
 require (
 	github.com/bamiaux/rez v0.0.0-20170731184118-29f4463c688b
-	github.com/disintegration/imaging v1.6.0
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/kapmahc/epub v0.1.1
 	github.com/mattn/go-sqlite3 v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/shermp/Kobo-UNCaGED
 
 require (
+	github.com/bamiaux/rez v0.0.0-20170731184118-29f4463c688b
 	github.com/disintegration/imaging v1.6.0
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/kapmahc/epub v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/bamiaux/rez v0.0.0-20170731184118-29f4463c688b h1:5Ci5wpOL75rYF6RQGRo
 github.com/bamiaux/rez v0.0.0-20170731184118-29f4463c688b/go.mod h1:obBQGGIFbbv9KWg92Qu9UHeD94JXmHD1jovY/z6I3O8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/disintegration/imaging v1.6.0 h1:nVPXRUUQ36Z7MNf0O77UzgnOb1mkMMor7lmJMJXc/mA=
-github.com/disintegration/imaging v1.6.0/go.mod h1:xuIt+sRxDFrHS0drzXUlCJthkJ8k7lkkUojDSR247MQ=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/kapmahc/epub v0.1.1 h1:a4fgmhh/q2vyzFR2QXOVohR2zAuQvbacCjMZ1LGr0lw=
@@ -22,8 +20,6 @@ github.com/shermp/UNCaGED/uc v0.2.0 h1:SeN0ZY6blq4IRaBAmK2wkvOJN3OPpRaxM2oLq3zX3
 github.com/shermp/UNCaGED/uc v0.2.0/go.mod h1:y9yAhXj5BN5S2EC8GTGlnUo0gX1q4JhkDQ70zRQGGSE=
 github.com/shermp/go-fbink-v2 v1.15.1 h1:CvLsaXxpKF1nYnqRvU7QKAjooZvCM/HhyjkLV7LsMjg=
 github.com/shermp/go-fbink-v2 v1.15.1/go.mod h1:88bOAwruwze/4JB/KW8uoyPtWm5OPa1BZEraFMHJgpQ=
-golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81 h1:00VmoueYNlNz/aHIilyyQz/MHSqGoWJzpFv/HW8xpzI=
-golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/bamiaux/rez v0.0.0-20170731184118-29f4463c688b h1:5Ci5wpOL75rYF6RQGRoqhEAU6xLJ6n/D4SckXX1yB74=
+github.com/bamiaux/rez v0.0.0-20170731184118-29f4463c688b/go.mod h1:obBQGGIFbbv9KWg92Qu9UHeD94JXmHD1jovY/z6I3O8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/disintegration/imaging v1.6.0 h1:nVPXRUUQ36Z7MNf0O77UzgnOb1mkMMor7lmJMJXc/mA=

--- a/kobo-uncaged/ku.toml
+++ b/kobo-uncaged/ku.toml
@@ -15,3 +15,18 @@ passwordList = []
 
 # Provide more verbose logging
 enableDebug = false
+
+# The following options tweak aspects of the thumbnail generation process
+[thumbnail]
+    # Choose what level of thumbnails you want generated. Options are "all", "partial", "none"
+    # "all" generates all thumbnails, including that used on the sleep screen.
+    # "partial" generates thumbnails used in the library views and home screen, and is faster than "all"
+    # "none" generates no thumbnails, and let's the Kobo software generate them.
+    generateLevel = "all"
+
+    # Choose which resize algorithm to use when generating thumbnails. Allowed options are
+    # "bilinear", "bicubic", "lanczos2", "lanczos3". Default is "bicubic"
+    resizeAlgorithm = "bicubic"
+
+    # Choose a Jpeg quality level between 0 and 100. Default is 90
+    jpegQuality = 90

--- a/kobo-uncaged/main.go
+++ b/kobo-uncaged/main.go
@@ -98,6 +98,7 @@ type KoboUncaged struct {
 		PreferKepub  bool
 		PasswordList []string
 		EnableDebug  bool
+		Thumbnail    thumbnailOption
 	}
 	dbRootDir         string
 	bkRootDir         string
@@ -148,6 +149,8 @@ func New(dbRootDir, sdRootDir string, updatingMD bool) (*KoboUncaged, error) {
 		log.Print(err)
 		return nil, err
 	}
+	ku.KuConfig.Thumbnail.validate()
+	ku.KuConfig.Thumbnail.setRezFilter()
 
 	if sdRootDir != "" && ku.KuConfig.PreferSDCard {
 		ku.useSDCard = true
@@ -494,9 +497,18 @@ func (ku *KoboUncaged) saveCoverImage(contentID string, size image.Point, imgB64
 	}
 	imgDir = filepath.Join(ku.bkRootDir, imgDir)
 	imgID := imgIDFromContentID(contentID)
-	jpegOpts := jpeg.Options{Quality: 90}
+	jpegOpts := jpeg.Options{Quality: ku.KuConfig.Thumbnail.JpegQuality}
 
-	for _, cover := range []koboCover{fullCover, libFull, libGrid} {
+	var coverEndings []koboCover
+	switch ku.KuConfig.Thumbnail.GenerateLevel {
+	case generateAll:
+		coverEndings = []koboCover{fullCover, libFull, libGrid}
+	case generatePartial:
+		coverEndings = []koboCover{libFull, libGrid}
+	default:
+		coverEndings = nil
+	}
+	for _, cover := range coverEndings {
 		nsz := cover.Resize(ku.device, sz)
 		nfn := filepath.Join(imgDir, cover.RelPath(imgID))
 
@@ -505,7 +517,7 @@ func (ku *KoboUncaged) saveCoverImage(contentID string, size image.Point, imgB64
 		var nimg image.Image
 		if !sz.Eq(nsz) {
 			nimg = image.NewYCbCr(image.Rect(0, 0, nsz.X, nsz.Y), img.(*image.YCbCr).SubsampleRatio)
-			rez.Convert(nimg, img, rez.NewBicubicFilter())
+			rez.Convert(nimg, img, ku.KuConfig.Thumbnail.rezFilter)
 		} else {
 			nimg = img
 			log.Println(" -- Skipped resize: already correct size")
@@ -585,8 +597,16 @@ func (ku *KoboUncaged) GetClientOptions() uc.ClientOptions {
 	opts.SupportedExt = append(opts.SupportedExt, ext...)
 	opts.DeviceName = "Kobo"
 	opts.DeviceModel = ku.device.Model()
-	fc := fullCover.Size(ku.device)
-	opts.CoverDims.Width, opts.CoverDims.Height = fc.X, fc.Y
+	var thumbSz image.Point
+	switch ku.KuConfig.Thumbnail.GenerateLevel {
+	case generateAll:
+		thumbSz = fullCover.Size(ku.device)
+	case generatePartial:
+		thumbSz = libFull.Size(ku.device)
+	default:
+		thumbSz = libGrid.Size(ku.device)
+	}
+	opts.CoverDims.Width, opts.CoverDims.Height = thumbSz.X, thumbSz.Y
 	return opts
 }
 

--- a/kobo-uncaged/main.go
+++ b/kobo-uncaged/main.go
@@ -510,6 +510,10 @@ func (ku *KoboUncaged) saveCoverImage(contentID string, size image.Point, imgB64
 			nimg = img
 			log.Println(" -- Skipped resize: already correct size")
 		}
+		// Optimization. No need to resize libGrid from the full cover size...
+		if cover == libFull {
+			img = nimg
+		}
 
 		if err := os.MkdirAll(filepath.Dir(nfn), 0755); err != nil {
 			log.Println(err)

--- a/kobo-uncaged/main.go
+++ b/kobo-uncaged/main.go
@@ -518,6 +518,7 @@ func (ku *KoboUncaged) saveCoverImage(contentID string, size image.Point, imgB64
 		if !sz.Eq(nsz) {
 			nimg = image.NewYCbCr(image.Rect(0, 0, nsz.X, nsz.Y), img.(*image.YCbCr).SubsampleRatio)
 			rez.Convert(nimg, img, ku.KuConfig.Thumbnail.rezFilter)
+			log.Printf(" -- Resized to %s\n", nimg.Bounds().Size())
 		} else {
 			nimg = img
 			log.Println(" -- Skipped resize: already correct size")

--- a/kobo-uncaged/main.go
+++ b/kobo-uncaged/main.go
@@ -505,8 +505,6 @@ func (ku *KoboUncaged) saveCoverImage(contentID string, size image.Point, imgB64
 		coverEndings = []koboCover{fullCover, libFull, libGrid}
 	case generatePartial:
 		coverEndings = []koboCover{libFull, libGrid}
-	default:
-		coverEndings = nil
 	}
 	for _, cover := range coverEndings {
 		nsz := cover.Resize(ku.device, sz)
@@ -889,7 +887,6 @@ func mainWithErrCode() returnCode {
 			return kuError
 		}
 		log.Println("Starting Calibre Connection")
-		ku.kup.kuPrintln(body, "Finishing up")
 		err = cc.Start()
 		if err != nil {
 			if err.Error() == "no password entered" {


### PR DESCRIPTION
This PR changes the image resizing library used from [disintegration/imaging](https://github.com/disintegration/imaging) to [bamiaux/rez](https://github.com/bamiaux/rez), as discussed in #16 

The change is primarily around performance. An initial "full thumbnail" test using the bicubic algorithm seems very promising performance wise.

I have also exposed some thumbnail generation configuration to the user in `ku.toml`. See that file for available options. This allows us to test various options and combinations to come up with a sane set of defaults, and to allow easy experimentation.

@NiLuJe would you mind testing this please?
@geek1011 would you mind reviewing the code on this please?