### PR TITLE
Build script improvements. Upgrade option added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Once the prerequisites are met, follow the next steps:
 
 1. `git clone github.com/shermp/Kobo-UNCaGED`
 2. `cd Kobo-UNCaGED`
-3. `./build-ku.sh`. This will download and build all further requirements, and create the necessary directory structure.
-4. Extract `./Build/KoboUncaged.zip` to the root of your Kobo user directory (`/mnt/onboard`).
+3. `./build-ku.sh`. This will download and build all further requirements, and create the necessary directory structure. To create an *upgrade* archive, use `./build-ku.sh upgrade` instead.
+4. Extract `./Build/KoboUncaged-${version}-${build_type}.zip` to the root of your Kobo user directory (`/mnt/onboard`).
 5. Unplug, then reboot your Kobo.
 
 ### Developing

--- a/build-ku.sh
+++ b/build-ku.sh
@@ -9,6 +9,13 @@ RED="\033[31;1m"
 YELLOW="\033[33;1m"
 GREEN="\033[32;1m"
 
+BUILD_TYPE="full"
+# Set a variable if we only want to build an upgrade archive
+if [ "$1" = "upgrade" ] || [ "$1" = "UPGRADE" ]; then
+    BUILD_UPGRADE=1
+    BUILD_TYPE="upgrade"
+fi
+
 # Check if the user has set their ARM toolchain name
 if [ -z "$CROSS_TC" ]; then
     printf "%bCROSS_TC variable is not set! Please set it before running this script! Eg: CROSS_TC=\"arm-kobo-linux-gnueabihf\"%b\n" "${RED}" "${END}"
@@ -21,11 +28,6 @@ if ! command -v "${CROSS_TC}-gcc"; then
     exit 1
 fi
 
-# Set variables required for Go and CGO
-# if [ -z "$GOPATH" ]; then
-#     printf "GOPATH not found! Please set this before running the script!"
-#     exit 1
-# fi
 export GOOS=linux
 export GOARCH=arm
 export CGO_ENABLED=1
@@ -33,15 +35,22 @@ export CGO_ENABLED=1
 export CC="${CROSS_TC}-gcc"
 export CXX="${CROSS_TC}-g++"
 
+# Setup out directory structure
+mkdir -p ./Build/prerequisites/output
+rm -rf ./Build/onboard
+
 mkdir -p ./Build/onboard/.adds/kobo-uncaged/bin
-mkdir -p ./Build/onboard/.adds/kobo-uncaged/fonts
 mkdir -p ./Build/onboard/.adds/kobo-uncaged/scripts
 mkdir -p ./Build/onboard/.adds/kobo-uncaged/config
-mkdir -p ./Build/onboard/.adds/kfmon/config
-cd ./Build || exit 1
+# Only make the following directories if we are not building an upgrade package
+if [ -z $BUILD_UPGRADE ]; then
+    mkdir -p ./Build/onboard/.adds/kobo-uncaged/fonts
+    mkdir -p ./Build/onboard/.adds/kfmon/config
+fi
+cd ./Build/prerequisites || exit 1
 
-# Build FBInk
-if [ ! -f ./onboard/.adds/kobo-uncaged/bin/fbink ] && [ ! -f ./onboard/.adds/kobo-uncaged/bin/button_scan ]; then
+# Retrieve and build FBInk, if required
+if [ ! -f ./output/fbink ] && [ ! -f ./output/button_scan ]; then
     printf "%bFBInk binaries not found. Building from source%b\n" "${YELLOW}" "${END}"
     if [ ! -d ./FBInk ]; then
         git clone --recursive --branch master https://github.com/NiLuJe/FBInk.git
@@ -53,67 +62,65 @@ if [ ! -f ./onboard/.adds/kobo-uncaged/bin/fbink ] && [ ! -f ./onboard/.adds/kob
         printf "%bMake failed to build 'button_scan'. Aborting%b\n" "${RED}" "${END}"
         exit 1
     fi
-    cp ./Release/button_scan ../onboard/.adds/kobo-uncaged/bin/button_scan
+    cp ./Release/button_scan ../output/button_scan
     # Clean for minimal build
     make clean
     if ! make MINIMAL=1; then
         printf "%bMake failed to build 'fbink'. Aborting%b\n" "${RED}" "${END}"
         exit 1
     fi
-    cp ./Release/fbink ../onboard/.adds/kobo-uncaged/bin/fbink
+    cp ./Release/fbink ../output/fbink
     cd -
     printf "%bFBInk binaries built%b\n" "${GREEN}" "${END}"
 fi
 
-# Get Go-FBInk-v2, if required
-if ! go list github.com/shermp/go-fbink-v2/gofbink; then
-    printf "%bGetting Go-FBInk-v2%b\n" "${YELLOW}" "${END}"
-    if ! go get github.com/shermp/go-fbink-v2/gofbink; then
-        printf "%bGo failed to get go-fbink-v2. Aborting%b\n" "${RED}" "${END}"
-        exit 1
-    fi
-    printf "%bGot Go-FBInk-v2%b\n" "${GREEN}" "${END}"
-fi
-
-# Copy the kobo-uncaged scripts to the build directory
-cp ../scripts/start-ku.sh ./onboard/.adds/kobo-uncaged/start-ku.sh
-cp ../scripts/run-ku.sh ./onboard/.adds/kobo-uncaged/scripts/run-ku.sh
-cp ../scripts/nickel-usbms.sh ./onboard/.adds/kobo-uncaged/scripts/nickel-usbms.sh
-
-# And the kfmon files
-cp ../kfmon/kobo-uncaged.ini ./onboard/.adds/kfmon/config/kobo-uncaged.ini
-cp ../kfmon/Kobo-UNCaGED.png ./onboard/Kobo-UNCaGED.png
-
-# Default config file
-cp ../kobo-uncaged/ku.toml ./onboard/.adds/kobo-uncaged/config/ku.toml.default
-
 # Next, obtain a TTF font. LiberationSans in our case
-if [ ! -f ./onboard/.adds/kobo-uncaged/fonts/LiberationSans-Regular.ttf ]; then
+if [ ! -f ./output/LiberationSans-Regular.ttf ]; then
     printf "%bFont not found. Downloading LiberationSans%b\n" "${YELLOW}" "${END}"
     wget https://github.com/liberationfonts/liberation-fonts/files/2926169/liberation-fonts-ttf-2.00.5.tar.gz
     tar -zxf ./liberation-fonts-ttf-2.00.5.tar.gz liberation-fonts-ttf-2.00.5/LiberationSans-Regular.ttf
-    cp ./liberation-fonts-ttf-2.00.5/LiberationSans-Regular.ttf ./onboard/.adds/kobo-uncaged/fonts/LiberationSans-Regular.ttf
+    cp ./liberation-fonts-ttf-2.00.5/LiberationSans-Regular.ttf ./output/LiberationSans-Regular.ttf
     printf "%bLiberationSans-Regular.ttf downloaded%b\n" "${GREEN}" "${END}"
 fi
-
+# Back to the top level Build directory
+cd ..
 # Now that we have everything, time to build Kobo-UNCaGED
 printf "%bBuilding Kobo-UNCaGED%b\n" "${YELLOW}" "${END}"
 cd ./onboard/.adds/kobo-uncaged/bin || exit 1
 ku_vers="$(git describe --tags)"
 go_ldflags="-s -w -X main.kuVersion=${ku_vers}"
-if ! go build -ldflags "$go_ldflags" github.com/shermp/Kobo-UNCaGED/kobo-uncaged; then
+if ! go build -ldflags "$go_ldflags" ../../../../../kobo-uncaged; then
     printf "%bGo failed to build kobo-uncaged. Aborting%b\n" "${RED}" "${END}"
     exit 1
 fi
 cd -
 printf "%bKobo-UNCaGED built%b\n" "${GREEN}" "${END}"
 
+# Copy the kobo-uncaged scripts to the build directory
+cp ../scripts/start-ku.sh ./onboard/.adds/kobo-uncaged/start-ku.sh
+cp ../scripts/run-ku.sh ./onboard/.adds/kobo-uncaged/scripts/run-ku.sh
+cp ../scripts/nickel-usbms.sh ./onboard/.adds/kobo-uncaged/scripts/nickel-usbms.sh
+
+# Default config file
+cp ../kobo-uncaged/ku.toml ./onboard/.adds/kobo-uncaged/config/ku.toml.default
+
+if [ -z BUILD_UPGRADE ]; then
+    # FBInk binaries
+    cp ./prerequisites/output/fbink ./onboard/.adds/kobo-uncaged/bin/fbink
+    cp ./prerequisites/output/button_scan ./onboard/.adds/kobo-uncaged/bin/button_scan
+    # Font
+    cp ./prerequisites/output/LiberationSans-Regular.ttf ./onboard/.adds/kobo-uncaged/fonts/LiberationSans-Regular.ttf
+    # And the kfmon files
+    cp ../kfmon/kobo-uncaged.ini ./onboard/.adds/kfmon/config/kobo-uncaged.ini
+    cp ../kfmon/Kobo-UNCaGED.png ./onboard/Kobo-UNCaGED.png
+fi
+
 # Finally, zip it all up
 printf "%bCreating release archive%b\n" "${YELLOW}" "${END}"
 cd ./onboard || exit 1
-if ! zip -r "../KoboUncaged-${ku_vers}.zip" .; then
+if ! zip -r "../KoboUncaged-${ku_vers}-${BUILD_TYPE}.zip" .; then
     printf "%bFailed to create zip archive. Aborting%b\n" "${RED}" "${END}"
     exit 1
 fi
 cd -
-printf "%b./Build/KoboUncaged-${ku_vers}.zip built%b\n" "${GREEN}" "${END}"
+printf "%b./Build/KoboUncaged-${ku_vers}-${BUILD_TYPE}.zip built%b\n" "${GREEN}" "${END}"


### PR DESCRIPTION
This PR adds an upgrade build option to the build script. I got sick of manually ignoring/overwriting the unzip process to avoid triggering kfmon. So the script can now build an upgrade archive without kfmon files, font file and FBInk binaries.

I've also performed some script reorganisation while I was at it.

@geek1011 with the project using modules, do I need a `go get` call anywhere? Or will `go build` fetch needed dependencies? I haven't tested on a fresh install, so am unsure.

@NiLuJe turns out, replacing the png file on device via ssh/scp triggers kfmon to launch the action. Slightly annoying, but I'm not sure if anything can be done about it...