### PR TITLE
Shell script updates for wpa_supplicant and USB power

### DIFF
--- a/kobo-uncaged/ku.toml
+++ b/kobo-uncaged/ku.toml
@@ -16,6 +16,11 @@ passwordList = []
 # Provide more verbose logging
 enableDebug = false
 
+# Enable the following option to allow Kobo-UNCaGED to launch with a USB cable connected.
+# Useful if you want to use KU while connected to a USB power source such as AC outlet or powerbank.
+# This is disabled by default to avoid mistakingly launching KU while connected to a PC.
+allowUSBPower = false
+
 # The following options tweak aspects of the thumbnail generation process
 [thumbnail]
     # Choose what level of thumbnails you want generated. Options are "all", "partial", "none"

--- a/scripts/nickel-usbms.sh
+++ b/scripts/nickel-usbms.sh
@@ -144,6 +144,9 @@ enable_wifi() {
         || env -u LD_LIBRARY_PATH \
             wpa_supplicant -D wext -s -i "${INTERFACE}" -O /var/run/wpa_supplicant -c /etc/wpa_supplicant/wpa_supplicant.conf -B
     
+    # Before obtaining an IP address via DHCP, we should determine whether wpa_supplicant connects successfully or not.
+    # We use the wpa_cli application to do this, checking 'wpa_state' for 'COMPLETED'. Some other states I've seen
+    # are DISCONNECTED, SCANNING and ASSOCIATING. There are probably others.
     WIFI_TIMEOUT=0
     while ! wpa_cli status | grep -q "wpa_state=COMPLETED"; do
         # If wpa_supplicant hasn't connected within 5 seconds, we couldn't connect to the Wifi network
@@ -154,7 +157,7 @@ enable_wifi() {
         usleep 250000
         WIFI_TIMEOUT=$(( WIFI_TIMEOUT + 1 ))
     done
-    
+
     # Obtain an IP address
     logmsg "I" "Acquiring IP"
     obtain_ip

--- a/scripts/run-ku.sh
+++ b/scripts/run-ku.sh
@@ -13,11 +13,14 @@ KU_TMP_DIR="$2"
 
 # Abort if the device is currently plugged in, as that's liable to confuse Nickel into actually starting a real USBMS session!
 # Which'd probably ultimately cause a crash with our shenanigans...
-if [ $(cat /sys/devices/platform/pmic_battery.1/power_supply/mc13892_charger/online) -ne 0 ]; then
-    # Sleep a bit to lose the race with Nickel's opening of our image
-    sleep 2
-    logmsg "C" "Device is currently plugged in. Aborting!"
-    exit 1
+# Except if we've specified 'allowUSBPower = true' in our ku.toml file
+if ! grep -qi "allowUSBPower *= *true" "/mnt/onboard/${KU_DIR}/config/ku.toml"; then 
+    if [ $(cat /sys/devices/platform/pmic_battery.1/power_supply/mc13892_charger/online) -ne 0 ]; then
+        # Sleep a bit to lose the race with Nickel's opening of our image
+        sleep 2
+        logmsg "C" "Device is currently plugged in. Aborting!"
+        exit 1
+    fi
 fi
 
 logmsg "N" "Entering USBMS mode..."

--- a/scripts/run-ku.sh
+++ b/scripts/run-ku.sh
@@ -14,7 +14,7 @@ KU_TMP_DIR="$2"
 # Abort if the device is currently plugged in, as that's liable to confuse Nickel into actually starting a real USBMS session!
 # Which'd probably ultimately cause a crash with our shenanigans...
 # Except if we've specified 'allowUSBPower = true' in our ku.toml file
-if ! grep -qi "allowUSBPower[[:blank:]]*=[[:blank:]]*true" "/mnt/onboard/${KU_DIR}/config/ku.toml"; then 
+if ! grep -qi "^[[:blank:]]*allowUSBPower[[:blank:]]*=[[:blank:]]*true" "/mnt/onboard/${KU_DIR}/config/ku.toml"; then 
     if [ $(cat /sys/devices/platform/pmic_battery.1/power_supply/mc13892_charger/online) -ne 0 ]; then
         # Sleep a bit to lose the race with Nickel's opening of our image
         sleep 2

--- a/scripts/run-ku.sh
+++ b/scripts/run-ku.sh
@@ -14,7 +14,7 @@ KU_TMP_DIR="$2"
 # Abort if the device is currently plugged in, as that's liable to confuse Nickel into actually starting a real USBMS session!
 # Which'd probably ultimately cause a crash with our shenanigans...
 # Except if we've specified 'allowUSBPower = true' in our ku.toml file
-if ! grep -qi "allowUSBPower *= *true" "/mnt/onboard/${KU_DIR}/config/ku.toml"; then 
+if ! grep -qi "allowUSBPower[[:blank:]]*=[[:blank:]]*true" "/mnt/onboard/${KU_DIR}/config/ku.toml"; then 
     if [ $(cat /sys/devices/platform/pmic_battery.1/power_supply/mc13892_charger/online) -ne 0 ]; then
         # Sleep a bit to lose the race with Nickel's opening of our image
         sleep 2


### PR DESCRIPTION
Well, I'm back from holiday. Time to ease back into this...

Just a couple of shell script updates to make things a little nicer.

The first update uses the wpa_cli application to ensure that wpa_supplicant connects before trying to obtain an IP address. While I haven't timed it, this check actually seems to improve Wifi connection time.

The second update adds an option to allow the user to launch KU if their Kobo is plugged into USB power. This is disabled by default.

@NiLuJe can you sanity check these changes please?

I will probably publish a new release after this PR.