### PR TITLE
Updated shell script & metadata update handling

### DIFF
--- a/kobo-uncaged/device/device.go
+++ b/kobo-uncaged/device/device.go
@@ -106,6 +106,7 @@ func New(dbRootDir, sdRootDir string, updatingMD bool, opts *KuOptions, vers str
 	if err = k.readUpdateMDfile(); err != nil {
 		return nil, fmt.Errorf("New: failed to read updated metadata file: %w", err)
 	}
+	os.Remove(filepath.Join(k.BKRootDir, kuUpdatedMDfile))
 
 	return k, err
 }
@@ -571,10 +572,6 @@ func (k *Kobo) SaveCoverImage(contentID string, size image.Point, imgB64 string)
 // or this run if updating via triggers
 func (k *Kobo) UpdateNickelDB() (bool, error) {
 	rerun := false
-	if !k.KuConfig.AddMetadataByTrigger {
-		// No matter what happens, we remove the 'metadata_update.kobouc' file when we're done
-		defer os.Remove(filepath.Join(k.BKRootDir, kuUpdatedMDfile))
-	}
 	var err error
 	tx, err := k.nickelDB.Begin()
 	if err != nil {

--- a/kobo-uncaged/device/types.go
+++ b/kobo-uncaged/device/types.go
@@ -57,7 +57,7 @@ type Kobo struct {
 	ContentIDprefix cidPrefix
 	useSDCard       bool
 	MetadataMap     map[string]uc.CalibreBookMeta
-	UpdatedMetadata []string
+	UpdatedMetadata map[string]struct{}
 	BooksInDB       map[string]struct{}
 	Passwords       *uncagedPassword
 	DriveInfo       uc.DeviceInfo

--- a/kobo-uncaged/kunc/kunc.go
+++ b/kobo-uncaged/kunc/kunc.go
@@ -118,7 +118,6 @@ func (ku *koboUncaged) UpdateMetadata(mdList []uc.CalibreBookMeta) error {
 		ku.k.UpdatedMetadata[cid] = struct{}{}
 	}
 	ku.k.WriteMDfile()
-	ku.k.WriteUpdateMDfile()
 	return nil
 }
 
@@ -185,7 +184,6 @@ func (ku *koboUncaged) SaveBook(md uc.CalibreBookMeta, book io.Reader, len int, 
 	ku.k.MetadataMap[cID] = md
 	if lastBook {
 		ku.k.WriteMDfile()
-		ku.k.WriteUpdateMDfile()
 	}
 	return err
 }
@@ -241,9 +239,6 @@ func (ku *koboUncaged) DeleteBook(book uc.BookID) error {
 	// Finally, write the new metadata files
 	if err = ku.k.WriteMDfile(); err != nil {
 		return fmt.Errorf("DeleteBook: error writing metadata file: %w", err)
-	}
-	if err = ku.k.WriteUpdateMDfile(); err != nil {
-		return fmt.Errorf("DeleteBook: error writing updated metadata file: %w", err)
 	}
 	return nil
 }

--- a/kobo-uncaged/kunc/kunc.go
+++ b/kobo-uncaged/kunc/kunc.go
@@ -115,7 +115,7 @@ func (ku *koboUncaged) UpdateMetadata(mdList []uc.CalibreBookMeta) error {
 		md.Thumbnail = nil
 		cid := util.LpathToContentID(md.Lpath, string(ku.k.ContentIDprefix))
 		ku.k.MetadataMap[cid] = md
-		ku.k.UpdatedMetadata = append(ku.k.UpdatedMetadata, cid)
+		ku.k.UpdatedMetadata[cid] = struct{}{}
 	}
 	ku.k.WriteMDfile()
 	ku.k.WriteUpdateMDfile()
@@ -171,7 +171,7 @@ func (ku *koboUncaged) SaveBook(md uc.CalibreBookMeta, book io.Reader, len int, 
 		return fmt.Errorf("SaveBook: error opening ebook file: %w", err)
 	}
 	defer destBook.Close()
-	ku.k.UpdatedMetadata = append(ku.k.UpdatedMetadata, cID)
+	ku.k.UpdatedMetadata[cID] = struct{}{}
 	// Note, the JSON format for covers should be in the form 'thumbnail: [w, h, "base64string"]'
 	if md.Thumbnail.Exists() {
 		w, h := md.Thumbnail.Dimensions()
@@ -237,14 +237,7 @@ func (ku *koboUncaged) DeleteBook(book uc.BookID) error {
 	// Now we remove the book from the metadata map
 	delete(ku.k.MetadataMap, cid)
 	// As well as the updated metadata list, if it was added to the list this session
-	l := len(ku.k.UpdatedMetadata)
-	for n := 0; n < l; n++ {
-		if ku.k.UpdatedMetadata[n] == cid {
-			ku.k.UpdatedMetadata[n] = ku.k.UpdatedMetadata[len(ku.k.UpdatedMetadata)-1]
-			ku.k.UpdatedMetadata = ku.k.UpdatedMetadata[:len(ku.k.UpdatedMetadata)-1]
-			break
-		}
-	}
+	delete(ku.k.UpdatedMetadata, cid)
 	// Finally, write the new metadata files
 	if err = ku.k.WriteMDfile(); err != nil {
 		return fmt.Errorf("DeleteBook: error writing metadata file: %w", err)

--- a/scripts/run-ku.sh
+++ b/scripts/run-ku.sh
@@ -107,12 +107,25 @@ logmsg "I" "Unmounting SD card"
 unmount_sd
 ret=$?
 logmsg "N" "SD card unmounted (${ret}) . . ."
-
-logmsg "I" "Waiting for content processing"
-./button_scan -w -u -q
-BS_RES=$?
+if [ $KU_RES -ne $KURC_RERUN ] || [ $KU_RES -ne $KURC_USBMS ]; then
+    if [ $KU_RES -eq $KURC_PWERR ]; then
+        logmsg "I" "Password issue. Check your ku.toml config file"
+    elif [ $KU_RES -eq $KURC_ERR ] || [ $KU_RES -eq $KURC_NFERR ]; then
+        logmsg "E" "Kobo UNCaGED exited with an error. Check syslog for error message"
+    elif [ $KU_RES -ne $KURC_SUCC ]; then
+        logmsg "C" "Kobo UNCaGED appears to have crashed, check ${KU_LOG}"
+    else
+        logmsg "I" "Success! Returning to home"
+    fi
+    remove_usb
 # Note, KU may have updated metadata, even if no new books are added
-if [ $KU_RES -eq $KURC_RERUN ] || [ $KU_RES -eq $KURC_USBMS ] || [ $BS_RES -eq 0 ]; then
+else
+    logmsg "I" "Waiting for content processing"
+    ./button_scan -w -u -q
+    BS_RES=$?
+    if [ $BS_RES -ne 0 ]; then
+        logmsg "I" "Something strange happened... (BS: -$(( 256 - BS_RES )))"
+    fi
     logmsg "N" "Updating metadata . . ."
     logmsg "I" "Entering USBMS mode . . ."
     insert_usb
@@ -174,13 +187,4 @@ if [ $KU_RES -eq $KURC_RERUN ] || [ $KU_RES -eq $KURC_USBMS ] || [ $BS_RES -eq 0
     fi
     logmsg "I" "Going back to Nickel"
     remove_usb
-elif [ $KU_RES -eq $KURC_PWERR ]; then
-    logmsg "I" "Password issue. Check your ku.toml config file"
-elif [ $KU_RES -eq $KURC_ERR ] || [ $KU_RES -eq $KURC_NFERR ]; then
-    logmsg "E" "Kobo UNCaGED exited with an error. Check syslog for error message"
-elif [ $KU_RES -ne $KURC_SUCC ]; then
-    logmsg "C" "Kobo UNCaGED appears to have crashed, check ${KU_LOG}"
-elif [ $KU_RES -ne $KURC_SUCC ] && [ $BS_RES -ne 0 ]; then
-    # FBInk returns negative error codes, fudge that back to the <errno.h> value...
-    logmsg "I" "Something strange happened... (KU: ${KU_RES}; BS: -$(( 256 - BS_RES )))"
 fi

--- a/scripts/run-ku.sh
+++ b/scripts/run-ku.sh
@@ -107,13 +107,13 @@ logmsg "I" "Unmounting SD card"
 unmount_sd
 ret=$?
 logmsg "N" "SD card unmounted (${ret}) . . ."
-if [ $KU_RES -ne $KURC_RERUN ] || [ $KU_RES -ne $KURC_USBMS ]; then
+if [ $KU_RES -ne $KURC_RERUN ] && [ $KU_RES -ne $KURC_USBMS ]; then
     if [ $KU_RES -eq $KURC_PWERR ]; then
         logmsg "I" "Password issue. Check your ku.toml config file"
     elif [ $KU_RES -eq $KURC_ERR ] || [ $KU_RES -eq $KURC_NFERR ]; then
         logmsg "E" "Kobo UNCaGED exited with an error. Check syslog for error message"
     elif [ $KU_RES -ne $KURC_SUCC ]; then
-        logmsg "C" "Kobo UNCaGED appears to have crashed, check ${KU_LOG}"
+        logmsg "C" "Kobo UNCaGED appears to have crashed, check\n${KU_LOG}"
     else
         logmsg "I" "Success! Returning to home"
     fi

--- a/scripts/run-ku.sh
+++ b/scripts/run-ku.sh
@@ -11,6 +11,14 @@ KU_DIR="$1"
 KU_TMP_DIR="$2"
 . ./nickel-usbms.sh
 
+# Set expected KU return codes as variables
+KURC_ERR=250
+KURC_SUCC=0
+KURC_RERUN=1
+KURC_USBMS=10
+KURC_PWERR=100
+KURC_NFERR=101
+
 # Abort if the device is currently plugged in, as that's liable to confuse Nickel into actually starting a real USBMS session!
 # Which'd probably ultimately cause a crash with our shenanigans...
 # Except if we've specified 'allowUSBPower = true' in our ku.toml file
@@ -104,7 +112,7 @@ logmsg "I" "Waiting for content processing"
 ./button_scan -w -u -q
 BS_RES=$?
 # Note, KU may have updated metadata, even if no new books are added
-if [ $KU_RES -eq 1 ] || [ $KU_RES -eq 10 ] || [ $BS_RES -eq 0 ]; then
+if [ $KU_RES -eq $KURC_RERUN ] || [ $KU_RES -eq $KURC_USBMS ] || [ $BS_RES -eq 0 ]; then
     logmsg "N" "Updating metadata . . ."
     logmsg "I" "Entering USBMS mode . . ."
     insert_usb
@@ -125,7 +133,7 @@ if [ $KU_RES -eq 1 ] || [ $KU_RES -eq 10 ] || [ $BS_RES -eq 0 ]; then
         BS_TIMEOUT=$(( BS_TIMEOUT + 1 ))
     done
 
-    if [ $KU_RES -ne 10 ]; then
+    if [ $KU_RES -ne $KURC_USBMS ]; then
         logmsg "I" "(Re)mounting onboard"
         mount_onboard
         ret=$?
@@ -166,13 +174,13 @@ if [ $KU_RES -eq 1 ] || [ $KU_RES -eq 10 ] || [ $BS_RES -eq 0 ]; then
     fi
     logmsg "I" "Going back to Nickel"
     remove_usb
-elif [ $KU_RES -eq 100 ]; then
+elif [ $KU_RES -eq $KURC_PWERR ]; then
     logmsg "I" "Password issue. Check your ku.toml config file"
-elif [ $KU_RES -eq 250 ] || [ $KU_RES -eq 101 ]; then
+elif [ $KU_RES -eq $KURC_ERR ] || [ $KU_RES -eq $KURC_NFERR ]; then
     logmsg "E" "Kobo UNCaGED exited with an error. Check syslog for error message"
-elif [ $KU_RES -ne 0 ]; then
+elif [ $KU_RES -ne $KURC_SUCC ]; then
     logmsg "C" "Kobo UNCaGED appears to have crashed, check ${KU_LOG}"
-elif [ $KU_RES -ne 0 ] && [ $BS_RES -ne 0 ]; then
+elif [ $KU_RES -ne $KURC_SUCC ] && [ $BS_RES -ne 0 ]; then
     # FBInk returns negative error codes, fudge that back to the <errno.h> value...
     logmsg "I" "Something strange happened... (KU: ${KU_RES}; BS: -$(( 256 - BS_RES )))"
 fi


### PR DESCRIPTION
Some posts on Mobileread have exposed some potential issues with the `run-ku.sh` script as it was, so I've reworked the final if-ladder to hopefully help solve the observed issue.

As part of the changes, I've also changed how the metadata is updated a bit. More specifically, the new way only requires a KU rerun/USBMS connection when new content is added, otherwise metadata is updated for existing content in the current run.

@NiLuJe could you check my shell script changes please?