### PR TITLE
Issue #35 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ override ARCHIVE_FILES := \
 	kobo-uncaged/static/ku.css:$(ARC_KU_ROOT)/static/ku.css \
 	kobo-uncaged/static/ku.js:$(ARC_KU_ROOT)/static/ku.js \
 	kobo-uncaged/templates/kuPage.tmpl:$(ARC_KU_ROOT)/templates/kuPage.tmpl \
-	config/nm-ku:$(ADDS_ROOT)/nm/kobo_uncaged
+	config/nm-ku:$(ARC_ADDS_ROOT)/nm/kobo_uncaged
 
 # Get a list of source files only from the above list
 override ARCHIVE_SRCS := $(foreach pair,$(ARCHIVE_FILES),$(word 1,$(subst :, ,$(pair))))

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/pgaskin/koboutils/v2 v2.1.1
-	github.com/shermp/UNCaGED v0.7.0
+	github.com/shermp/UNCaGED v0.7.1
 	github.com/unrolled/render v1.0.3
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/pgaskin/koboutils/v2 v2.1.1 h1:Or5y+z8rXlip0Al8tiSj+Fb9NkuLhkcw1UPpzP
 github.com/pgaskin/koboutils/v2 v2.1.1/go.mod h1:wTzkDIlsxmUyfwfspGcm0Ap+HOxSUYV0S8kMYrf+0gM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/shermp/UNCaGED v0.7.0 h1:4yyYnPnVzQB9HY+olM9BaDQQYPbIFsSgeyCE3DTb/qM=
-github.com/shermp/UNCaGED v0.7.0/go.mod h1:T31e1xhY6gznBiL0R24kxaRiYlU7PNIrUJd5JsIr0n8=
+github.com/shermp/UNCaGED v0.7.1 h1:wmb5G4TcBnGAojne1Zr6HpFbak4Lx5aeyx2bbLe3yAY=
+github.com/shermp/UNCaGED v0.7.1/go.mod h1:T31e1xhY6gznBiL0R24kxaRiYlU7PNIrUJd5JsIr0n8=
 github.com/slongfield/pyfmt v0.0.0-20180124071345-020a7cb18bca h1:fO9hIZRL+kteo13eh51GqkUdZf/NpMmZsi8ob6b1eOg=
 github.com/slongfield/pyfmt v0.0.0-20180124071345-020a7cb18bca/go.mod h1:41QiOYlRDMkcA4GnlnV0jfYUyqxKHYnUeaQRAvpezw8=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/scripts/nm-start-ku.sh
+++ b/scripts/nm-start-ku.sh
@@ -41,6 +41,9 @@ fi
 ip link set lo up
 logmsg "I" "Enabled loopback interface"
 
+# The zip file may not contain the 'config' directory, so ensure it is created
+[ -d "${KU_DIR}/config" ] || mkdir "${KU_DIR}/config"
+
 cd ${KU_DIR}
 
 logmsg "I" "Starting Kobo UNCaGED" 1000


### PR DESCRIPTION
This fixes issues identified in #35 

This fixes the following issues:
* fix config directory not being created for new installs
* Correct the location of the NickelMenu config file in the zip archive
* Includes upstream UNCaGED changes to fix issue when ratings field is a float