### PR TITLE
Implement fixes and improvements from MobileRead

### DIFF
--- a/config/nm-ku
+++ b/config/nm-ku
@@ -9,4 +9,5 @@ menu_item :main :Kobo UNCaGED :cmd_output :1000:quiet: /mnt/onboard/.adds/kobo-u
         chain_success : cmd_output  :1000:quiet: cp /mnt/onboard/.adds/kobo-uncaged/NickelDBus/ndb-kr.tgz /mnt/onboard/.kobo/KoboRoot.tgz
         chain_success : nickel_misc : rescan_books_full
         chain_always  : skip        : -1
-    chain_success : cmd_spawn   :quiet: exec /mnt/onboard/.adds/kobo-uncaged/nm-start-ku.sh
+    chain_success : cmd_spawn   :quiet: exec env KU_LOGFILE="/mnt/onboard/.adds/kobo-uncaged/ku.log" /mnt/onboard/.adds/kobo-uncaged/nm-start-ku.sh
+    #chain_success : cmd_spawn   :quiet: exec /mnt/onboard/.adds/kobo-uncaged/nm-start-ku.sh

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/pgaskin/koboutils/v2 v2.1.1
-	github.com/shermp/UNCaGED v0.7.1
+	github.com/shermp/UNCaGED v0.7.2
 	github.com/unrolled/render v1.0.3
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/pgaskin/koboutils/v2 v2.1.1 h1:Or5y+z8rXlip0Al8tiSj+Fb9NkuLhkcw1UPpzP
 github.com/pgaskin/koboutils/v2 v2.1.1/go.mod h1:wTzkDIlsxmUyfwfspGcm0Ap+HOxSUYV0S8kMYrf+0gM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/shermp/UNCaGED v0.7.1 h1:wmb5G4TcBnGAojne1Zr6HpFbak4Lx5aeyx2bbLe3yAY=
-github.com/shermp/UNCaGED v0.7.1/go.mod h1:T31e1xhY6gznBiL0R24kxaRiYlU7PNIrUJd5JsIr0n8=
+github.com/shermp/UNCaGED v0.7.2 h1:Ms+jJt7qWUA0f/9OKaCx+U8n4EeU/lop4r6lzxsObsc=
+github.com/shermp/UNCaGED v0.7.2/go.mod h1:T31e1xhY6gznBiL0R24kxaRiYlU7PNIrUJd5JsIr0n8=
 github.com/slongfield/pyfmt v0.0.0-20180124071345-020a7cb18bca h1:fO9hIZRL+kteo13eh51GqkUdZf/NpMmZsi8ob6b1eOg=
 github.com/slongfield/pyfmt v0.0.0-20180124071345-020a7cb18bca/go.mod h1:41QiOYlRDMkcA4GnlnV0jfYUyqxKHYnUeaQRAvpezw8=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/kobo-uncaged/device/device.go
+++ b/kobo-uncaged/device/device.go
@@ -54,10 +54,6 @@ func isBrowserViewSignal(vs *dbus.Signal) (bool, error) {
 	return vs.Body[0].(string) == "N3BrowserView", nil
 }
 
-func getSupportedExtraFormats() []string {
-	return []string{"mobi", "pdf", "cbz", "cbr", "txt", "html", "rtf"}
-}
-
 // New creates a Kobo object, ready for use
 func New(dbRootDir, sdRootDir string, bindAddress string, disableNDB bool, vers string) (*Kobo, error) {
 	var err error
@@ -317,12 +313,13 @@ func (k *Kobo) GetDeviceOptions() (ext []string, model string, thumbSz image.Poi
 	// Order matters, which is why slices are used, and not maps
 	// Calibre uses the order to determine which format to send, if a book has multiple
 	// compatible formats
+	extraFormats := []string{"mobi", "pdf", "cbz", "cbr", "txt", "html", "rtf"}
 	var tmpExt []string
 	// First, a list of all formats we support
 	if k.KuConfig.PreferKepub {
-		tmpExt = append([]string{"kepub", "epub"}, getSupportedExtraFormats()...)
+		tmpExt = append([]string{"kepub", "epub"}, extraFormats...)
 	} else {
-		tmpExt = append([]string{"epub", "kepub"}, getSupportedExtraFormats()...)
+		tmpExt = append([]string{"epub", "kepub"}, extraFormats...)
 	}
 	// Then, create a new list without the formats the user excludes via the config, preserving order
 	for _, e := range tmpExt {

--- a/kobo-uncaged/device/types.go
+++ b/kobo-uncaged/device/types.go
@@ -45,6 +45,7 @@ type KuOptions struct {
 	LibOptions      map[string]KuLibOptions `json:"libOptions"`
 	DirectConnIndex int                     `json:"directConnIndex"`
 	DirectConn      []uc.CalInstance        `json:"directConn"`
+	ExcludeFormats  []string                `json:"excludeFormats"`
 }
 
 // KuLibOptions contains per-library options

--- a/kobo-uncaged/device/types.go
+++ b/kobo-uncaged/device/types.go
@@ -54,16 +54,17 @@ type KuLibOptions struct {
 }
 
 type webUIinfo struct {
-	KUVersion      string `json:"kuVersion"`
-	StorageType    string `json:"storageType"`
-	ScreenDPI      int    `json:"screenDPI"`
-	ExitPath       string `json:"exitPath"`
-	DisconnectPath string `json:"disconnectPath"`
-	AuthPath       string `json:"authPath"`
-	SSEPath        string `json:"ssePath"`
-	ConfigPath     string `json:"configPath"`
-	InstancePath   string `json:"instancePath"`
-	LibInfoPath    string `json:"libInfoPath"`
+	KUVersion        string   `json:"kuVersion"`
+	StorageType      string   `json:"storageType"`
+	ScreenDPI        int      `json:"screenDPI"`
+	SupportedFormats []string `json:"supportedFormats"`
+	ExitPath         string   `json:"exitPath"`
+	DisconnectPath   string   `json:"disconnectPath"`
+	AuthPath         string   `json:"authPath"`
+	SSEPath          string   `json:"ssePath"`
+	ConfigPath       string   `json:"configPath"`
+	InstancePath     string   `json:"instancePath"`
+	LibInfoPath      string   `json:"libInfoPath"`
 }
 
 type webConfig struct {

--- a/kobo-uncaged/static/ku.css
+++ b/kobo-uncaged/static/ku.css
@@ -16,6 +16,10 @@ body {
     display: inline-block;
     width: 33%;
 }
+
+.formatChk {
+    display: inline-block;
+}
 .ku-cfg-buttons {
     text-align: center;
 }

--- a/kobo-uncaged/static/ku.js
+++ b/kobo-uncaged/static/ku.js
@@ -308,14 +308,11 @@ function sendConfig() {
     kuConfig.opts.preferSDCard = document.getElementById('preferSDCard').checked;
     kuConfig.opts.preferKepub = document.getElementById('preferKepub').checked;
     kuConfig.opts.enableDebug = document.getElementById('enableDebug').checked;
-    // var exclFormats = document.getElementById('excludeFormats').value.split(",").map(function(item){return item.trim()});
-    // kuConfig.opts.excludeFormats = exclFormats.filter(function(e){return e;});
     var exclFormats = [];
     var fmtLabels = document.querySelectorAll('#excludeFormatsContainer label');
     for(var i = 0; i < fmtLabels.length; i++) {
         var lbl = fmtLabels[i];
-        var chk = document.getElementById(lbl.htmlFor);
-        if (!chk.checked) {
+        if (!document.getElementById(lbl.htmlFor).checked) {
             exclFormats.push(lbl.innerText);
         }
     }
@@ -376,11 +373,7 @@ function handleShowKUCfg(resp) {
         var formatLabels = document.querySelectorAll('#excludeFormatsContainer label');
         for(var i = 0; i < formatLabels.length; i++) {
             var lbl = formatLabels[i];
-            var chk = document.getElementById(lbl.htmlFor);
-            chk.checked = true;
-            if (kuConfig.opts.excludeFormats.indexOf(lbl.innerText) >= 0) {
-                chk.checked = false;
-            }
+            document.getElementById(lbl.htmlFor).checked = (kuConfig.opts.excludeFormats.indexOf(lbl.innerText) === -1);
         }
         document.getElementById('generateLevel').value = kuConfig.opts.thumbnail.generateLevel;
         document.getElementById('resizeAlgorithm').value = kuConfig.opts.thumbnail.resizeAlgorithm;

--- a/kobo-uncaged/static/ku.js
+++ b/kobo-uncaged/static/ku.js
@@ -308,6 +308,8 @@ function sendConfig() {
     kuConfig.opts.preferSDCard = document.getElementById('preferSDCard').checked;
     kuConfig.opts.preferKepub = document.getElementById('preferKepub').checked;
     kuConfig.opts.enableDebug = document.getElementById('enableDebug').checked;
+    var exclFormats = document.getElementById('excludeFormats').value.split(",").map(function(item){return item.trim()});
+    kuConfig.opts.excludeFormats = exclFormats.filter(function(e){return e;});
     kuConfig.opts.thumbnail.generateLevel = gl.options[gl.selectedIndex].value;
     kuConfig.opts.thumbnail.resizeAlgorithm = rs.options[rs.selectedIndex].value;
     var jpgQuality = parseInt(document.getElementById('jpegQuality').value);
@@ -360,6 +362,7 @@ function handleShowKUCfg(resp) {
         document.getElementById('preferSDCard').checked = kuConfig.opts.preferSDCard;
         document.getElementById('preferKepub').checked = kuConfig.opts.preferKepub;
         document.getElementById('enableDebug').checked = kuConfig.opts.enableDebug;
+        document.getElementById('excludeFormats').value = kuConfig.opts.excludeFormats.toString();
         document.getElementById('generateLevel').value = kuConfig.opts.thumbnail.generateLevel;
         document.getElementById('resizeAlgorithm').value = kuConfig.opts.thumbnail.resizeAlgorithm;
         document.getElementById('jpegQuality').value = kuConfig.opts.thumbnail.jpegQuality;

--- a/kobo-uncaged/static/ku.js
+++ b/kobo-uncaged/static/ku.js
@@ -9,7 +9,7 @@ function getKoboZoom() {
 function setKoboSizes(dpi) {
     var height = Math.round(window.innerHeight * 0.95);
     var width = Math.round(window.innerWidth * 0.95);
-    var baseFontSize = 16 * (dpi / 96);
+    var baseFontSize = 14 * (dpi / 96);
     baseFontSize = (baseFontSize * 0.8) / getKoboZoom();
     document.documentElement.style.fontSize = baseFontSize.toFixed(4) + 'px';
     var containerDiv = document.getElementById("kuapp");
@@ -112,7 +112,7 @@ function setupEventHandlers() {
         instList.addEventListener('click', selectCalInstance);
         instList.dataset.eventInstances = "true";
     }
-    var cfgLabels = document.querySelectorAll(".ku-cfg-row > label");
+    var cfgLabels = document.querySelectorAll(".ku-cfg-row > label, #excludeFormatsLabel");
     for (var i = 0; i < cfgLabels.length; i++) {
         cfgLabels[i].addEventListener('click', showCfgHelpText);
     }
@@ -308,8 +308,18 @@ function sendConfig() {
     kuConfig.opts.preferSDCard = document.getElementById('preferSDCard').checked;
     kuConfig.opts.preferKepub = document.getElementById('preferKepub').checked;
     kuConfig.opts.enableDebug = document.getElementById('enableDebug').checked;
-    var exclFormats = document.getElementById('excludeFormats').value.split(",").map(function(item){return item.trim()});
-    kuConfig.opts.excludeFormats = exclFormats.filter(function(e){return e;});
+    // var exclFormats = document.getElementById('excludeFormats').value.split(",").map(function(item){return item.trim()});
+    // kuConfig.opts.excludeFormats = exclFormats.filter(function(e){return e;});
+    var exclFormats = [];
+    var fmtLabels = document.querySelectorAll('#excludeFormatsContainer label');
+    for(var i = 0; i < fmtLabels.length; i++) {
+        var lbl = fmtLabels[i];
+        var chk = document.getElementById(lbl.htmlFor);
+        if (!chk.checked) {
+            exclFormats.push(lbl.innerText);
+        }
+    }
+    kuConfig.opts.excludeFormats = exclFormats;
     kuConfig.opts.thumbnail.generateLevel = gl.options[gl.selectedIndex].value;
     kuConfig.opts.thumbnail.resizeAlgorithm = rs.options[rs.selectedIndex].value;
     var jpgQuality = parseInt(document.getElementById('jpegQuality').value);
@@ -362,7 +372,16 @@ function handleShowKUCfg(resp) {
         document.getElementById('preferSDCard').checked = kuConfig.opts.preferSDCard;
         document.getElementById('preferKepub').checked = kuConfig.opts.preferKepub;
         document.getElementById('enableDebug').checked = kuConfig.opts.enableDebug;
-        document.getElementById('excludeFormats').value = kuConfig.opts.excludeFormats.toString();
+        //document.getElementById('excludeFormats').value = kuConfig.opts.excludeFormats.toString();
+        var formatLabels = document.querySelectorAll('#excludeFormatsContainer label');
+        for(var i = 0; i < formatLabels.length; i++) {
+            var lbl = formatLabels[i];
+            var chk = document.getElementById(lbl.htmlFor);
+            chk.checked = true;
+            if (kuConfig.opts.excludeFormats.indexOf(lbl.innerText) >= 0) {
+                chk.checked = false;
+            }
+        }
         document.getElementById('generateLevel').value = kuConfig.opts.thumbnail.generateLevel;
         document.getElementById('resizeAlgorithm').value = kuConfig.opts.thumbnail.resizeAlgorithm;
         document.getElementById('jpegQuality').value = kuConfig.opts.thumbnail.jpegQuality;

--- a/kobo-uncaged/templates/kuPage.tmpl
+++ b/kobo-uncaged/templates/kuPage.tmpl
@@ -36,6 +36,12 @@
                 <input type="checkbox" id="enableDebug" name="enableDebug">
             </div>
             <div class="ku-cfg-row">
+                <label for="excludeFormats" data-help-text="Comma separated list of formats to disable">
+                    Exclude formats
+                </label>
+                <input type="text" id="excludeFormats" name="excludeFormats">
+            </div>
+            <div class="ku-cfg-row">
                 <label for="generateLevel" data-help-text="Pre-generate thumbnails if set to 'All' or 'Partial'. 
                 'Partial' generates library thumbnails, 'All' additionally generates the sleep thumbnail. 
                 Set 'None' to get Nickel to generate thumbnails">

--- a/kobo-uncaged/templates/kuPage.tmpl
+++ b/kobo-uncaged/templates/kuPage.tmpl
@@ -36,12 +36,6 @@
                 <input type="checkbox" id="enableDebug" name="enableDebug">
             </div>
             <div class="ku-cfg-row">
-                <label for="excludeFormats" data-help-text="Comma separated list of formats to disable">
-                    Exclude formats
-                </label>
-                <input type="text" id="excludeFormats" name="excludeFormats">
-            </div>
-            <div class="ku-cfg-row">
                 <label for="generateLevel" data-help-text="Pre-generate thumbnails if set to 'All' or 'Partial'. 
                 'Partial' generates library thumbnails, 'All' additionally generates the sleep thumbnail. 
                 Set 'None' to get Nickel to generate thumbnails">
@@ -80,6 +74,19 @@
                     </select>
                     <button type="button" id="cfgAddConn" data-event-conn-add="false">+</button>
                     <button type="button" id="cfgDelConn" data-event-conn-delete="false">&#8722;</button>
+                </div>
+            </div>
+             <div class="ku-cfg-fmt-row">
+                <div id="excludeFormatsLabel" data-help-text="Set of supported formats to send to Calibre">
+                    Supported Formats
+                </div>
+                <div id="excludeFormatsContainer">
+                    {{range .SupportedFormats}}
+                        <div class="formatChk">
+                            <input type="checkbox" id="format_{{.}}" name="format_{{.}}">
+                            <label for="format_{{.}}">{{.}}</label>
+                        </div>
+                    {{end}}
                 </div>
             </div>
             <div class="ku-cfg-row ku-cfg-buttons">

--- a/kobo-uncaged/util/util.go
+++ b/kobo-uncaged/util/util.go
@@ -46,6 +46,16 @@ func ContentIDtoLpath(cid, cidPrefix string) string {
 	return strings.TrimPrefix(cid, cidPrefix)
 }
 
+// StringSliceContains test if val is contained in strSlice
+func StringSliceContains(strSlice []string, val string) bool {
+	for _, s := range strSlice {
+		if s == val {
+			return true
+		}
+	}
+	return false
+}
+
 // SafeSQLString constructs a safe string to feed to SQLite3 CLI
 // Queries made in Go should use prepared statements/parameters
 // instead. This is also not safe for LIKE queries

--- a/scripts/ku-lib.sh
+++ b/scripts/ku-lib.sh
@@ -42,8 +42,13 @@ logmsg() {
     LOG_MSG="${2}"
     TOAST_DURATION=${3:-0}
 
-    # Send to syslog
-    logger -t "UNCaGED" -p daemon.${LOG_LEVEL} "${LOG_MSG}"
+    if [ -z "$KU_LOGFILE" ]; then
+        # Send to syslog
+        logger -t "Kobo-UNCaGED" -p daemon.${LOG_LEVEL} "${LOG_MSG}"
+    else
+        # Append to KU_LOGFILE
+        printf "%s [Kobo-UNCaGED] %s\n" "$(date +'%b %d %T')" "$LOG_MSG" >> "$KU_LOGFILE"
+    fi
 
     # Print to console
     printf "%b%s%b\n" "${PRINT_COLOR}" "${LOG_MSG}" "${END}"

--- a/scripts/nm-start-ku.sh
+++ b/scripts/nm-start-ku.sh
@@ -4,10 +4,12 @@ KU_DIR=/mnt/onboard/.adds/kobo-uncaged
 KU_BIN=${KU_DIR}/bin/ku
 SQLITE_BIN=${KU_DIR}/bin/sqlite3
 NICKEL_DB=/mnt/onboard/.kobo/KoboReader.sqlite
-KU_LOG=${KU_DIR}/ku_error.log
 
 KU_REPL_MD=${KU_DIR}/replace-book.sql
 KU_UPDATE_MD=${KU_DIR}/updated-md.sql
+
+# Delete previous log file if it exists
+[ -f "$KU_LOGFILE" ] && rm "$KU_LOGFILE"
 
 # Inport logmsg function
 . ${KU_DIR}/scripts/ku-lib.sh


### PR DESCRIPTION
This is a PR that aims to implement the fixes and improvements identified in the [MR thread](https://www.mobileread.com/forums/showthread.php?t=320149) from post #73

The following changes and fixes are implemented
* Fix parsing "application_id" metadata field, inherited from upstream
* Increase TCP deadline to 60s, inherited from upstream
* Allow logging to file instead of syslog, because firmware 4.25...
* Implement a new "Exclude Format" option. This is a comma separated list of formats that should be excluded from the list of 'supported' formats. This forces a Calibre conversion to another format if an attempt is made to send such formats

I'll mark this PR as draft until I've confirmed the fixes on the MR thread.