### PR TITLE
Switch to docker build

### DIFF
--- a/.github/workflows/build-ku.yml
+++ b/.github/workflows/build-ku.yml
@@ -6,37 +6,24 @@ jobs:
   build_ku:
     runs-on: ubuntu-20.04
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17'
-
-      - name: Setup koxtoolchain
-        run: |
-          curl -sSL -o kobo-tc.zip https://github.com/koreader/koxtoolchain/releases/download/2021.12/kobo.zip
-          unzip kobo-tc.zip
-          tar -xzvf kobo.tar.gz -C ${HOME}/
-          echo ${HOME}/x-tools/arm-kobo-linux-gnueabihf/bin >> $GITHUB_PATH
-          echo "CROSS_COMPILE=arm-kobo-linux-gnueabihf-" >> $GITHUB_ENV
-
       - name: Checkout repository
         uses: actions/checkout@v2
-      
+
       - name: Build
-        run: make
-      
+        run: ./build.sh
+
       - name: Prepare directory for upload
         run: |
           mkdir -p build/Kobo-UNCaGED
           cd build/Kobo-UNCaGED
           unzip ../Kobo-UNCaGED.zip
-      
+
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
           name: Kobo-UNCaGED
           path: build/Kobo-UNCaGED
-      
+
       - name: Create draft release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/v')

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM aricodes/kobo-toolchain:latest
+
+WORKDIR /uncaged
+COPY . .
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir -p build
+
+docker build -t kobo-uncaged:latest .
+docker run -v "$PWD/build":/uncaged/build kobo-uncaged:latest

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source /koxtoolchain/refs/x-compile.sh kobo env
+make


### PR DESCRIPTION
This uses a premade image to save you time on building releases and to make locally building a little easier. Currently I've got a job on one of my build servers that builds a fresh version of the toolchain weekly, although it looks like that repository hasn't been updated in quite some time so I may bump that to monthly.

This is one of my favorite pieces of software and you've done an incredible job with the user experience so I wanted to contribute in some small way. Thank you for helping reignite my love of reading!!

Closes #33